### PR TITLE
Collections endpoint

### DIFF
--- a/app/controllers/api/v0/machine_collections_controller.rb
+++ b/app/controllers/api/v0/machine_collections_controller.rb
@@ -1,0 +1,9 @@
+class Api::V0::MachineCollectionsController < ApplicationController
+  def index
+    user = User.find(params[:user_id])
+
+    collections = user.machine_collections
+
+    render json: MachineCollectionSerializer.new(collections)
+  end
+end

--- a/app/serializers/machine_collection_serializer.rb
+++ b/app/serializers/machine_collection_serializer.rb
@@ -1,0 +1,5 @@
+class MachineCollectionSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :id, :title, :cached_tag_list, :slug
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,7 @@ Rails.application.routes.draw do
           get :me
         end
       end
+      get "/:user_id/collections", to: "machine_collections#index"
       resources :tags, only: [:index] do
         collection do
           get "/onboarding", to: "tags#onboarding"

--- a/spec/factories/machine_collections.rb
+++ b/spec/factories/machine_collections.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :machine_collection do
+    user
+    sequence(:title) { |n| "Collection-#{n}" }
+    cached_tag_list { "tagged-interest" }
+    slug { "random-generated-slug" }
+  end
+end

--- a/spec/requests/api/v0/collections_spec.rb
+++ b/spec/requests/api/v0/collections_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "Api::V0::Articles", type: :request do
+  describe "GET /api/:user_id/collections" do
+    let(:user) { create(:user) }
+
+    before do
+      create_list(:machine_collection, 5, user_id: user.id)
+    end
+
+    it "returns a list of collections and their titles" do
+      get "/api/#{user.id}/collections"
+
+      expect(response).to be_successful
+
+      parsed = JSON.parse(response.body, symbolize_names: true)
+
+      expect(parsed[:data].length).to eq(5)
+      expect(parsed[:data].first[:attributes][:title]).to eq("Collection-1")
+      expect(parsed[:data].first[:attributes][:slug]).not_to eq(nil)
+      expect(parsed[:data].first[:attributes][:cached_tag_list]).not_to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Expose endpoint at '/api/:user_id/collections' which provides a JSON of all of a given user's `machine_collection`s. Create JSON through FastJsonapi gem with serializer and have JSON adhere to API standards.

## Related Tickets & Documents
Issue #29 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
