### PR TITLE
Change title to link to article show page

### DIFF
--- a/app/views/machine_collections/show.html.erb
+++ b/app/views/machine_collections/show.html.erb
@@ -2,6 +2,6 @@
 
 <div class="machine_collection_articles">
   <% @collection_articles.map do |article| %>
-    <li>Title: <%= article.title %>, Page views: <%= article.page_views_count %></li>
+    <li>Title: <%= link_to "#{article.title}", "/#{article.cached_user_username}/#{article.slug}"%>, Page views: <%= article.page_views_count %></li>
   <% end %>
 </div>

--- a/spec/user_views_a_collection_show_spec.rb
+++ b/spec/user_views_a_collection_show_spec.rb
@@ -15,19 +15,25 @@ RSpec.describe "Collection show page", type: :system do
     valid_article_1 = create(:article, tags: "javascript", created_at: three_days_ago, page_views_count: 5)
     valid_article_2 = create(:article, tags: "javascript", created_at: three_days_ago, page_views_count: 15)
     valid_article_3 = create(:article, tags: "javascript", created_at: three_days_ago, page_views_count: 0)
-    invalid_article = create(:article, tags: "javascript", created_at: ten_days_ago)
+    invalid_article_1 = create(:article, tags: "javascript", created_at: ten_days_ago)
+    invalid_article_2 = create(:article, tags: "ruby", created_at: ten_days_ago)
 
     visit "/#{user.id}/collections/#{machine_collection.id}"
 
     expect(page).to have_content("Articles in #{machine_collection.title}")
-    
+
     within ".machine_collection_articles" do
       expect(page.all('li')[0]).to have_content("Title: #{valid_article_2.title}")
       expect(page.all('li')[0]).to have_content("Page views: #{valid_article_2.page_views_count}")
       expect(page.all('li')[1]).to have_content("Title: #{valid_article_1.title}")
       expect(page.all('li')[1]).to have_content("Page views: #{valid_article_1.page_views_count}")
       expect(page.all('li')[2]).to have_content(valid_article_3.title)
-      expect(page).to_not have_content("#{invalid_article.title}")
+      expect(page).to_not have_content("#{invalid_article_1.title}")
+      expect(page).to_not have_content("#{invalid_article_2.title}")
+
+      click_link "#{valid_article_2.title}"
     end
+
+    expect(current_path).to eq("/#{valid_article_2.cached_user_username}/#{valid_article_2.slug}")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Refactored the article titles on a collection's show page so that the title of the article links to that article's show page
- After clicking on that article's show page, the page views count increases on the collection show page
- Added expectation to test to test that link routes to correct page
- Added expectation to test to ensure that a collection only displays articles whose tags match the user's selected tags

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
